### PR TITLE
Eliminate multiple calls to os.environ()

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -5,7 +5,7 @@ import os
 app = Flask(__name__)
 
 # On Bluemix, get the port number from the environment variable VCAP_APP_PORT
-# When running this app on the local machine, default the port will to 8080
+# When running this app on the local machine, default the port to 8080
 port = int(os.getenv('VCAP_APP_PORT', 8080))
 
 @app.route('/')

--- a/hello.py
+++ b/hello.py
@@ -4,10 +4,9 @@ import os
 
 app = Flask(__name__)
 
-if os.getenv("VCAP_APP_PORT"):
-    port = int(os.getenv("VCAP_APP_PORT"))
-else:
-    port = 8080
+# On Bluemix, get the port number from the environment variable VCAP_APP_PORT
+# When running this app on the local machine, default the port will to 8080
+port = int(os.getenv('VCAP_APP_PORT', 8080))
 
 @app.route('/')
 def hello_world():


### PR DESCRIPTION
Add comments to make it clear that we want this app to run either on Bluemix or on the local machine.
