### PR TITLE
Procfile changes, example not running properly on CF App

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python hello.py
+web: python -m flask run -h 0.0.0.0 -p 8080

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ cf push
 
 This can take a minute. If there is an error in the deployment process you can use the command `cf logs <Your-App-Name> --recent` to troubleshoot.
 
+Set the `FLASK_APP` environment variable. This example is using [Python Flask][a92f987c], a Python Microframework. The `FLASK_APP` variable needs as value the name of your `hello.py` file. You can set the variable using the command
+
+```
+cf set-env GetStartedPython FLASK_APP hello.py
+```
+
+  [a92f987c]: https://github.com/pallets/flask "Flask"
+
 When deployment completes you should see a message indicating that your app is running.  View your app at the URL listed in the output of the push command.  You can also issue the
   ```
 cf apps


### PR DESCRIPTION
Hi there!

First of all, thank you for taking the trouble to provide this example! Unfortunately, I had some difficulties with the deployment. After following the steps in the tutorial, it was not possible to deploy the app in Cloud Foundry. Everything works great locally, but once the project is pushed into the cloud, Cloud Foundry ignores any host and port parameters.

After a long search I found the solution and was able to deploy the app successfully. In the procfile the start parameter had to be adjusted and Python flask had to be informed via -h and -p flag about the corresponding settings of the host and port. Also, an environment variable had to be set in the Cloud Foundry app (FLASK_APP), without which Flask could not find and start the webservice. 

I have adapted the procfile and README.md of the example here so that it can be executed correctly locally and remotely.