### PR TITLE
Updated document link about app manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python hello.py
 
 To deploy to IBM Cloud, it can be helpful to set up a manifest.yml file. One is provided for you with the sample. Take a moment to look at it.
 
-The manifest.yml includes basic information about your app, such as the name, how much memory to allocate for each instance and the route. In this manifest.yml **random-route: true** generates a random route for your app to prevent your route from colliding with others.  You can replace **random-route: true** with **host: myChosenHostName**, supplying a host name of your choice. [Learn more...](https://console.bluemix.net/docs/manageapps/depapps.html#appmanifest)
+The manifest.yml includes basic information about your app, such as the name, how much memory to allocate for each instance and the route. In this manifest.yml **random-route: true** generates a random route for your app to prevent your route from colliding with others.  You can replace **random-route: true** with **host: myChosenHostName**, supplying a host name of your choice. [Learn more...](https://cloud.ibm.com/docs/cloud-foundry-public?topic=cloud-foundry-public-deployingapps#appmanifest)
  ```
  applications:
  - name: GetStartedPython


### PR DESCRIPTION
The old link doesnt exists anymore. I think that this is the new one.

The old link redirects for this link: https://cloud.ibm.com/docs/manageapps/depapps.html#appmanifest
That shows this message:

"Sorry, this content isn’t available.
It seems we can’t find what you’re looking for. Try the IBM Cloud Docs search to find information."

I changed that link for: https://cloud.ibm.com/docs/cloud-foundry-public?topic=cloud-foundry-public-deployingapps
Here the documentation talks about the manifests, so I think this is the right one. 